### PR TITLE
Skill Icon Animations

### DIFF
--- a/src/components/AboutMeComponents/Skills/SkillIcon.tsx
+++ b/src/components/AboutMeComponents/Skills/SkillIcon.tsx
@@ -1,0 +1,48 @@
+import { Tooltip, Fade } from "@mui/material";
+import { motion } from "motion/react";
+import { useState } from "react";
+import style from "./Skills.module.scss";
+import { SkillIconData } from "./data/skillsIconData";
+
+interface SkillIconProps {
+  iconData: SkillIconData;
+}
+
+const SkillIcon = (props: SkillIconProps) => {
+  const { title, Icon, iconProps } = props.iconData;
+
+  const [isFlipped, setIsFlipped] = useState<boolean>(false);
+
+  const defaultClassNames = `${style["skill-icon"]} ${
+    style[`${title.toLowerCase()}-icon`]
+  }`;
+
+  const iconClassName = iconProps.className
+    ? `${defaultClassNames} ${style[iconProps.className]}`
+    : defaultClassNames;
+
+  return (
+    <div
+      className={style["skill-icon-container"]}
+      onClick={() => setIsFlipped(!isFlipped)}
+    >
+      <Tooltip title={title} slots={{ transition: Fade }} placement="top">
+        <motion.div
+          className={style["skill-icon-inner-container"]}
+          initial={false}
+          animate={{ rotateY: isFlipped ? 180 : 0 }}
+          transition={{ duration: 0.65, ease: "easeInOut" }}
+        >
+          <motion.div className={style["skill-icon-front"]}>
+            <Icon className={iconClassName} color={iconProps.primaryColor} />
+          </motion.div>
+          <motion.div className={style["skill-icon-back"]}>
+            <Icon className={iconClassName} color={iconProps.secondaryColor} />
+          </motion.div>
+        </motion.div>
+      </Tooltip>
+    </div>
+  );
+};
+
+export default SkillIcon;

--- a/src/components/AboutMeComponents/Skills/Skills.module.scss
+++ b/src/components/AboutMeComponents/Skills/Skills.module.scss
@@ -16,13 +16,36 @@
   .skill-icon-container {
     perspective: 1000px;
 
-    .skill-icon:hover {
-      scale: 1.1;
+    .skill-icon-inner-container {
+      height: 5rem;
+      width: 5rem;
+      position: relative;
+      transform-style: preserve-3d;
+    }
+
+    .skill-icon-front,
+    .skill-icon-back {
+      height: 100%;
+      width: 100%;
+      position: absolute;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      backface-visibility: hidden;
+      cursor: pointer;
+    }
+
+    .skill-icon-back {
+      transform: rotateY(180deg);
     }
   }
 
   .react-icon {
-    animation: spin infinite 10s linear;
+    animation: spin infinite 8s linear;
+  }
+
+  .react-icon:hover {
+    animation-duration: 4s;
   }
 
   @keyframes spin {

--- a/src/components/AboutMeComponents/Skills/Skills.tsx
+++ b/src/components/AboutMeComponents/Skills/Skills.tsx
@@ -1,42 +1,18 @@
 import AboutMeContainer from "../AboutMeContainer/AboutMeContainer";
-import Tooltip from "@mui/material/Tooltip";
-import Fade from "@mui/material/Fade";
-import { SkillIconData, skillsIconsData } from "./data/skillsIconData";
+
+import { skillsIconsData } from "./data/skillsIconData";
 import {
   AboutMeContentProps,
   splitSkillsArray,
 } from "../../../utils/aboutMeUtils";
 
 import style from "./Skills.module.scss";
-
-interface SkillIconProps {
-  iconData: SkillIconData;
-}
+import SkillIcon from "./SkillIcon";
 
 const Skills = (props: AboutMeContentProps) => {
   const { label } = props;
 
   const skillsDataRows = splitSkillsArray(skillsIconsData);
-
-  const SkillIcon = (props: SkillIconProps) => {
-    const { title, Icon, iconProps } = props.iconData;
-
-    const defaultClassNames = `${style["skill-icon"]} ${
-      style[`${title.toLowerCase()}-icon`]
-    }`;
-
-    const iconClassName = iconProps.className
-      ? `${defaultClassNames} ${style[iconProps.className]}`
-      : defaultClassNames;
-
-    return (
-      <div className={style["skill-icon-container"]}>
-        <Tooltip title={title} slots={{ transition: Fade }} placement="top">
-          <Icon className={iconClassName} color={iconProps.color} />
-        </Tooltip>
-      </div>
-    );
-  };
 
   return (
     <AboutMeContainer heading={`My skills`} aria-label={label}>

--- a/src/components/AboutMeComponents/Skills/data/skillsIconData.ts
+++ b/src/components/AboutMeComponents/Skills/data/skillsIconData.ts
@@ -12,7 +12,8 @@ export interface SkillIconData {
   Icon: IconType;
   iconProps: {
     className?: string;
-    color: string;
+    primaryColor: string;
+    secondaryColor: string;
   };
 }
 
@@ -21,70 +22,80 @@ export const skillsIconsData: SkillIconData[] = [
     title: "TypeScript",
     Icon: TbBrandTypescript,
     iconProps: {
-      color: "#3178c6",
+      primaryColor: "#3178c6",
+      secondaryColor: "#00273f",
     },
   },
   {
     title: "HTML",
     Icon: TiHtml5,
     iconProps: {
-      color: "#e34c26",
+      primaryColor: "#e34c26",
+      secondaryColor: "#f06529",
     },
   },
   {
     title: "React",
     Icon: FaReact,
     iconProps: {
-      color: "#0081a3",
+      primaryColor: "#0081a3",
+      secondaryColor: "#00d8ff",
     },
   },
   {
     title: "GitHub",
     Icon: FaSquareGithub,
     iconProps: {
-      color: "#000000",
-    },
-  },
-  {
-    title: "CSS",
-    Icon: DiCss3,
-    iconProps: {
-      color: "#264de4",
-    },
-  },
-  {
-    title: "GraphQL",
-    Icon: GrGraphQl,
-    iconProps: {
-      color: "#e535ab",
+      primaryColor: "#000000",
+      secondaryColor: "#6e5494",
     },
   },
   {
     title: "Java",
     Icon: FaJava,
     iconProps: {
-      color: "#007396",
+      primaryColor: "#007396",
+      secondaryColor: "#ED8B00",
+    },
+  },
+  {
+    title: "GraphQL",
+    Icon: GrGraphQl,
+    iconProps: {
+      primaryColor: "#e535ab",
+      secondaryColor: "#FFFFFF",
+    },
+  },
+  {
+    title: "CSS",
+    Icon: DiCss3,
+    iconProps: {
+      primaryColor: "#264de4",
+      secondaryColor: "#663399",
     },
   },
   {
     title: "Springboot",
     Icon: BiLogoSpringBoot,
     iconProps: {
-      color: "#6db33f",
+      primaryColor: "#6db33f",
+      secondaryColor: "#FFFFFF",
     },
   },
   {
     title: "Git",
     Icon: FaGitSquare,
     iconProps: {
-      color: "#3d2d00",
+      primaryColor: "F1502F",
+      secondaryColor: "#3d2d00",
     },
   },
   {
     title: "Jira",
     Icon: FaJira,
     iconProps: {
-      color: "#2684ff",
+      primaryColor: "#2684ff",
+      secondaryColor: "#253858",
     },
   },
 ];


### PR DESCRIPTION
# This PR:

- Adds animations to the "Skills" icons
  - Each skill icon can animate a card flip on click.  This will be refactored to use an interval in the future
  - The 2nd face of the card will feature the secondary logo color
  - Adds a constant rotation to the `React` atom logo
  - Extracts the `SkillIcon` code to it's own component